### PR TITLE
Fixed get_all_sites issue.

### DIFF
--- a/craigslist/sites.py
+++ b/craigslist/sites.py
@@ -13,7 +13,7 @@ def get_all_sites():
     for box in soup.findAll('div', {'class': 'box'}):
         for a in box.findAll('a'):
             # Remove protocol and get subdomain
-            site = a.attrs['href'].rsplit('/', 1)[1].split('.')[0]
+            site = a.attrs['href'].rsplit('//', 1)[1].split('.')[0]
             sites.add(site)
 
     return sites


### PR DESCRIPTION
Craigslist must have added an extra '/' to the href for their official sites ex: href="//longisland.craigslist.org/">long island
Noticed this when attempting to use the library (it's awesome). A not a real site error was thrown when I was trying to use the library, so I started to investigate the get_all_sites() function in sites.py. Added an extra '/' to the split and voila it worked.