### PR TITLE
Fixing Python3 compatibility

### DIFF
--- a/craigslist/__init__.py
+++ b/craigslist/__init__.py
@@ -1,17 +1,18 @@
-from bs4 import BeautifulSoup
 import logging
 try:
     from Queue import Queue  # PY2
 except ImportError:
     from queue import Queue  # PY3
-import requests
-from requests.exceptions import RequestException
-from six import iteritems
 from threading import Thread
 try:
     from urlparse import urljoin  # PY2
 except ImportError:
     from urllib.parse import urljoin  # PY3
+
+from bs4 import BeautifulSoup
+import requests
+from requests.exceptions import RequestException
+from six import iteritems
 
 from .sites import get_all_sites
 

--- a/craigslist/__init__.py
+++ b/craigslist/__init__.py
@@ -13,6 +13,7 @@ from bs4 import BeautifulSoup
 import requests
 from requests.exceptions import RequestException
 from six import iteritems
+from six.moves import range
 
 from .sites import get_all_sites
 
@@ -271,7 +272,7 @@ class CraigslistBase(object):
                 queue.task_done()
 
         threads = []
-        for _ in xrange(workers):
+        for _ in range(workers):
             thread = Thread(target=geotagger)
             thread.start()
             threads.append(thread)


### PR DESCRIPTION
Replacing `xrange` by `six`'s `range`

Bonus: separating standard from third-party modules' imports