### PR TITLE
Add min bedroom/bathroom flags to CraigslistHousing

### DIFF
--- a/craigslist/__init__.py
+++ b/craigslist/__init__.py
@@ -380,6 +380,8 @@ class CraigslistHousing(CraigslistBase):
         'dogs_ok': {'url_key': 'pets_dog', 'value': 1},
         'min_price': {'url_key': 'min_price', 'value': None},
         'max_price': {'url_key': 'max_price', 'value': None},
+        'min_bedrooms': {'url_key': 'min_bedrooms', 'value': None},
+        'min_bathrooms': {'url_key': 'min_bathrooms', 'value': None},
         'min_ft2': {'url_key': 'minSqft', 'value': None},
         'max_ft2': {'url_key': 'maxSqft', 'value': None},
         'search_distance': {'url_key': 'search_distance', 'value': None},


### PR DESCRIPTION
This code allows the following example to work.

```from craigslist import CraigslistHousing
cl_h = CraigslistHousing(site='sfbay', area='sfc', category='apa',
                         filters={'min_price': 6000, 'min_bedrooms': 5, 'min_bathrooms': 2})

for result in cl_h.get_results(sort_by='newest', geotagged=True):
    print(result)
```