### PR TITLE
Include body and images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ develop-eggs
 .installed.cfg
 pip-log.txt
 .DS_Store
+.venv

--- a/craigslist/__init__.py
+++ b/craigslist/__init__.py
@@ -152,7 +152,8 @@ class CraigslistBase(object):
         sublinks = soup.find('ul', {'class': 'sublinks'})
         return sublinks and sublinks.find('a', text=area) is not None
 
-    def get_results(self, limit=None, start=0, sort_by=None, geotagged=False):
+    def get_results(self, limit=None, start=0, sort_by=None, geotagged=False,
+                    include_details=False):
         """
         Get results from Craigslist based on the specified filters.
 
@@ -224,8 +225,12 @@ class CraigslistBase(object):
                 if self.custom_result_fields:
                     self.customize_result(result, row)
 
-                if geotagged and result['has_map']:
-                    self.geotag_result(result)
+                if (geotagged and result['has_map']) or include_details:
+                    detail_soup = self.fetch_content(result['url'])
+                    if geotagged and result['has_map']:
+                        self.geotag_result(result, detail_soup)
+                    if include_details:
+                        self.include_details(result, detail_soup)
 
                 yield result
                 results_yielded += 1
@@ -241,24 +246,44 @@ class CraigslistBase(object):
         """ Add custom/delete/alter fields to result. """
         pass  # Override in subclass to add category-specific fields.
 
-    def geotag_result(self, result):
+    def geotag_result(self, result, soup):
         """ Adds (lat, lng) to result. """
 
         self.logger.debug('Geotagging result ...')
 
-        if result['has_map']:
-            response = requests_get(result['url'], logger=self.logger)
-            self.logger.info('GET %s', response.url)
-            self.logger.info('Response code: %s', response.status_code)
-
-            if response.ok:
-                soup = bs(response.content)
-                map = soup.find('div', {'id': 'map'})
-                if map:
-                    result['geotag'] = (float(map.attrs['data-latitude']),
-                                        float(map.attrs['data-longitude']))
+        map = soup.find('div', {'id': 'map'})
+        if map:
+            result['geotag'] = (float(map.attrs['data-latitude']),
+                                float(map.attrs['data-longitude']))
 
         return result
+
+    def include_details(self, result, soup):
+        """ Adds description, images to result """
+
+        self.logger.debug('Adding details to result...')
+
+        body = soup.find('section', {'id': 'postingbody'})
+        result['body'] = body.text.strip()
+
+        image_tags = soup.find_all('img')
+        images = []
+        # the first image is always a repeat, skip it
+        for img in image_tags[1:]:
+            img_link = img['src'].replace('50x50c', '600x450')
+            images.append(img_link)
+
+        result['images'] = images
+
+    def fetch_content(self, url):
+        response = requests_get(url, logger=self.logger)
+        self.logger.info('GET %s', response.url)
+        self.logger.info('Response code: %s', response.status_code)
+
+        if response.ok:
+            return bs(response.content)
+
+        return None
 
     def geotag_results(self, results, workers=8):
         """

--- a/craigslist/__init__.py
+++ b/craigslist/__init__.py
@@ -21,6 +21,10 @@ ALL_SITES = get_all_sites()  # All the Craiglist sites
 RESULTS_PER_REQUEST = 100  # Craigslist returns 100 results per request
 
 
+def bs(content):
+    return BeautifulSoup(content, 'html.parser')
+
+
 def requests_get(*args, **kwargs):
     """
     Retries if a RequestException is raised (could be a connection error or
@@ -39,7 +43,7 @@ def requests_get(*args, **kwargs):
 def get_list_filters(url):
     list_filters = {}
     response = requests_get(url)
-    soup = BeautifulSoup(response.content, 'html.parser')
+    soup = bs(response.content)
     for list_filter in soup.find_all('div', class_='search-attribute'):
         filter_key = list_filter.attrs['data-attr']
         filter_labels = list_filter.find_all('label')
@@ -144,7 +148,7 @@ class CraigslistBase(object):
         base_url = self.url_templates['base']
         response = requests_get(base_url % {'site': self.site},
                                 logger=self.logger)
-        soup = BeautifulSoup(response.content, 'html.parser')
+        soup = bs(response.content)
         sublinks = soup.find('ul', {'class': 'sublinks'})
         return sublinks and sublinks.find('a', text=area) is not None
 
@@ -177,7 +181,7 @@ class CraigslistBase(object):
             self.logger.info('Response code: %s', response.status_code)
             response.raise_for_status()  # Something failed?
 
-            soup = BeautifulSoup(response.content, 'html.parser')
+            soup = bs(response.content)
             if not total:
                 totalcount = soup.find('span', {'class': 'totalcount'})
                 total = int(totalcount.text) if totalcount else 0
@@ -248,7 +252,7 @@ class CraigslistBase(object):
             self.logger.info('Response code: %s', response.status_code)
 
             if response.ok:
-                soup = BeautifulSoup(response.content, 'html.parser')
+                soup = bs(response.content)
                 map = soup.find('div', {'id': 'map'})
                 if map:
                     result['geotag'] = (float(map.attrs['data-latitude']),


### PR DESCRIPTION
Add another option to get_results called include_details which also fetches the body of the listing as well as the urls of all the images. The listing is only fetched once and reused for both the geotag logic and the include_details logic.