### PR TITLE
Add bathrooms count to housing search

### DIFF
--- a/craigslist/__init__.py
+++ b/craigslist/__init__.py
@@ -314,7 +314,7 @@ class CraigslistBase(object):
             if attrgroup:
                 bedroom_bathroom = attrgroup.find('span', 'shared-line-bubble').text
                 if 'Ba' in bedroom_bathroom:
-                    r = re.findall(r'(\d*\.\d+|\d+)Ba', bedroom_bathroom)
+                    r = re.findall(r'(\S+)Ba', bedroom_bathroom)
                     result['bathrooms'] = r[0] if r else None
 
     def fetch_content(self, url):

--- a/craigslist/__init__.py
+++ b/craigslist/__init__.py
@@ -314,7 +314,7 @@ class CraigslistBase(object):
             if attrgroup:
                 bedroom_bathroom = attrgroup.find('span', 'shared-line-bubble').text
                 if 'Ba' in bedroom_bathroom:
-                    r = re.findall(r'(\d+)Ba', bedroom_bathroom)
+                    r = re.findall(r'(\d*\.\d+|\d+)Ba', bedroom_bathroom)
                     result['bathrooms'] = r[0] if r else None
 
     def fetch_content(self, url):


### PR DESCRIPTION
Add bathrooms count to housing search.

- If the class is `CraigslistHousing`, add `bathrooms` to the result by loading the result page.
- If you prefer, this could be optional and configured by the `include_details` parameter (or a new one).