### PR TITLE
Don't log warnings for listings that have been removed

### DIFF
--- a/craigslist/base.py
+++ b/craigslist/base.py
@@ -370,6 +370,8 @@ class CraigslistBase(object):
 
         if response.ok:
             return utils.bs(response.content)
+        elif response.status_code == 404:
+            return None
 
         self.logger.warning("GET %s returned not OK response code: %s "
                             "(skipping)", url, response.status_code)


### PR DESCRIPTION
Sometimes, listings that violate Craigslist's TOS will be removed, but remain searchable. This change stops logging warnings for these non-existent listings. Here's an example from the cars & trucks section which consistently displays in searches but whose listing page returns an HTTP 404.
![image](https://user-images.githubusercontent.com/66852150/181366496-da42b20c-42c0-49c1-b8e7-030fe2c51cd7.png)